### PR TITLE
Removed sticky styling from footer section

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -76,13 +76,9 @@ body {
 }
 
 .footer {
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  width: 100%;
   color: white;
+  margin-top: 150px;
   text-align: center;
-  margin-bottom: 15px;
 }
 
 .footer a {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -62,13 +62,9 @@ body {
 }
 
 .footer {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    width: 100%;
     color: white;
+    margin-top: 150px;
     text-align: center;
-    margin-bottom: 15px;
 
     a {
         color: white;


### PR DESCRIPTION
The footer now no longer sticks to the bottom of the page and is instead separated from the body of the interface by way of a `margin-top` value.